### PR TITLE
test_requires Time::HiRes

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,6 +11,7 @@ requires 'Test::More' => 0.88; # Test::More 0.88 is really needed
 
 test_requires 'App::Prove';
 test_requires 'Test::Requires';
+test_requires 'Time::HiRes';
 
 tests 't/*.t t/*/*.t t/*/*/*.t';
 author_tests 'xt';


### PR DESCRIPTION
I know Time::HiRes should always be present since it's core module, but it's not installed by default on RedHat for some reason.
I never really used RedHat until an hour ago, so maybe it's just misconfiguration... but still, depending on core module won't hurt.
