### PR TITLE
Fix the code for Perl::Critic 1.118

### DIFF
--- a/lib/Test/SharedFork.pm
+++ b/lib/Test/SharedFork.pm
@@ -90,12 +90,15 @@ BEGIN {
                 require Data::Dumper;
                 die "Cannot fetch object: " . Data::Dumper::Dumper($builder);
             }
+            ## no critic (ValuesAndExpressions::ProhibitAccessOfPrivateData)
             $obj->{test_sharedfork_hacked}++;
             $STORE->set( $klass => $obj );
         }
     } else {
         # older Test::Builder
         $STORE = Test::SharedFork::Store->new(
+            ## Grabbing at the guts of Test::Builder on purpose
+            ## no critic (ValuesAndExpressions::ProhibitAccessOfPrivateData)
             cb => sub {
                 my $store = shift;
                 tie $builder->{Curr_Test}, 'Test::SharedFork::Scalar',

--- a/lib/Test/SharedFork/Array.pm
+++ b/lib/Test/SharedFork/Array.pm
@@ -42,7 +42,7 @@ sub STORE {
 
     my $share = $self->{share};
     my $cur = $share->get($self->{key});
-    $cur->[$index] = $val;
+    $cur->[$index] = $val;       ## no critic (ProhibitAccessOfPrivateData)
     $share->set($self->{key} => $cur);
 }
 

--- a/lib/Test/SharedFork/Store.pm
+++ b/lib/Test/SharedFork/Store.pm
@@ -33,7 +33,7 @@ sub open {
     if (my $cb = $self->{callback_on_open}) {
         $cb->($self);
     }
-    sysopen my $fh, $self->{filename}, O_RDWR|O_CREAT or die $!;
+    sysopen my $fh, $self->{filename}, O_RDWR|O_CREAT or die $!;  ## no critic (ProhibitBitwiseOperators)
     $fh->autoflush(1);
     $self->{fh} = $fh;
 }
@@ -56,6 +56,7 @@ sub set {
 
     $self->_reopen_if_needed;
 
+    ## no critic (ProhibitAccessOfPrivateData)
     seek $self->{fh}, 0, SEEK_SET or die $!;
     my $dat = Storable::fd_retrieve($self->{fh});
     $dat->{$key} = $val;
@@ -100,6 +101,7 @@ sub new {
 
     $store->_reopen_if_needed;
 
+    ## no critic (ProhibitAccessOfPrivateData)
     if ($store->{lock}++ == 0) {
         flock $store->{fh}, LOCK_EX or die $!;
     }


### PR DESCRIPTION
Most of the cases are grabbing at the guts of Test::Builder, which is evil but
necessary, or of objects which don't have accessors.

ProhibitBitwiseOperators cannot be configured.  See rt.cpan.org 84750 for a possible fix.
