### PR TITLE
Add use FileHandle to Store.pm

### DIFF
--- a/lib/Test/SharedFork/Store.pm
+++ b/lib/Test/SharedFork/Store.pm
@@ -5,6 +5,7 @@ use Storable ();
 use Fcntl ':seek', ':DEFAULT', ':flock';
 use File::Temp ();
 use IO::Handle;
+use FileHandle;
 
 sub new {
     my $class = shift;


### PR DESCRIPTION
I am not sure entirely why this is needed, but in our environment `perl
Makefile.PL --skipdeps` started failing for dists that had requires 'Test::TCP' in them,
and the error was

```
Can't locate object method "autoflush" via package "FileHandle" at
/usr/local/share/perl/5.10.1/Test/SharedFork/Store.pm line 37.
```

Trying to load Test::TCP by itself worked, and running `perl Makefile.PL` without
skipdeps also worked. In `Module::AutoInstall` there is a call to `_check_lock` that
is not run if you do `skipdeps`, and that check ends up loading a bunch of modules,
one of them is `FileHandle`.

I have been unable to figure out a test for this, or for that matter, completely
understand what is going on, so if you have suggestions for other places to look,
I'd be more than welcome to look there :)
