### PR TITLE
not to fail because of a separator

### DIFF
--- a/t/06_fail_lineno.t
+++ b/t/06_fail_lineno.t
@@ -19,6 +19,5 @@ my $out = do {
 
 unlike($out, qr{lib/Test/SharedFork});
 {
-    my $path = catfile(qw(t 06_fail_lineno.t));
-    like($out, qr{\Q$path\E line \d+\.});
+    like($out, qr{t[\\/]06_fail_lineno\.t line \d+\.});
 }


### PR DESCRIPTION
Path comparison may fail depending on the situations under Win32, because both forward and back slashes may be used as a separator.

> prove -lvwr t\06_fail_lineno.t # pass
> prove -lvwr t/06_fail_lineno.t # fail
