### PR TITLE
Skip tests requiring fork() when no fork() is available

### DIFF
--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -1,8 +1,17 @@
 use strict;
 use warnings;
-use Test::More tests => 43;
+use Config;
+use Test::More;
 use Test::SharedFork;
 use Time::HiRes qw/sleep/;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
+plan tests => 43;
 
 my $pid = fork();
 if ($pid == 0) {

--- a/t/02_fork_method.t
+++ b/t/02_fork_method.t
@@ -1,7 +1,16 @@
 use strict;
 use warnings;
-use Test::More tests => 43;
+use Config;
+use Test::More;
 use Test::SharedFork;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
+plan tests => 43;
 
 my $pid = Test::SharedFork->fork();
 if ($pid == 0) {

--- a/t/03_toomany_run.t
+++ b/t/03_toomany_run.t
@@ -1,7 +1,16 @@
 use strict;
 use warnings;
-use Test::More tests => 30;
+use Config;
+use Test::More;
 use Test::SharedFork;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
+plan tests => 30;
 
 for (1..10) {
     my $pid = Test::SharedFork->fork();

--- a/t/04_test_before_fork.t
+++ b/t/04_test_before_fork.t
@@ -1,8 +1,17 @@
 use strict;
 use warnings;
 
-use Test::More tests => 3;
+use Config;
+use Test::More;
 use Test::SharedFork;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
+plan tests => 3;
 
 ok(1, 'one');
 if (!Test::SharedFork::fork) {

--- a/t/05_nest.t
+++ b/t/05_nest.t
@@ -1,7 +1,16 @@
 use strict;
 use warnings;
-use Test::More tests => 4;
+use Config;
+use Test::More;
 use Test::SharedFork;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
+plan tests => 4;
 
 &main;exit 0;
 

--- a/t/10_subtest.t
+++ b/t/10_subtest.t
@@ -1,9 +1,18 @@
 use strict;
 use warnings;
 use utf8;
-use Test::More tests => 1;
+use Config;
+use Test::More;
 use Test::Requires {'Test::More' => 0.96};
 use App::Prove;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
+plan tests => 1;
 
 TODO: {
     local $TODO = 'subtest is not supported yet';

--- a/t/12_is_passing.t
+++ b/t/12_is_passing.t
@@ -1,8 +1,15 @@
 use strict;
 use warnings;
 use utf8;
+use Config;
 use Test::More;
 use Test::SharedFork;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 sub do_in_fork {
     my ( $action ) = @_;


### PR DESCRIPTION
If you build perl on Windows without -DPERL_IMPLICIT_SYS (which I do, in
order to enable -DPEL_MALLOC, which seems faster than using the system
malloc()) then you don't get the fork() emulation and several of
Test-SharedFork's tests fail.

This commit skips those tests in the same manner as various other CPAN
modules do in this case. This allows a normal "cpan install ..." of
Test-SharedFork or anything depending on it (e.g. Plack) to succeed
without having to "force" anything.
