### PR TITLE
stop inheriting from Tie::Scalar

### DIFF
--- a/lib/Test/SharedFork/Scalar.pm
+++ b/lib/Test/SharedFork/Scalar.pm
@@ -1,7 +1,6 @@
 package Test::SharedFork::Scalar;
 use strict;
 use warnings;
-use base 'Tie::Scalar';
 
 # create new tied scalar
 sub TIESCALAR {


### PR DESCRIPTION
Tie::Scalar has no actual functionality, only stub methods.  Inheriting from it serves no purpose.